### PR TITLE
Streamlined the output message. Below is an example:

### DIFF
--- a/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java
+++ b/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTBroker3MDB.java
@@ -42,7 +42,7 @@ import com.ibm.websphere.samples.daytrader.util.TimerStat;
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "NonDurable") })
 public class DTBroker3MDB implements MessageListener {
     private final MDBStats mdbStats;
-    private int statInterval = 1000;
+    private int statInterval = 10000;
 
     
     // TODO: Using local interface, make it configurable to use remote?
@@ -57,7 +57,7 @@ public class DTBroker3MDB implements MessageListener {
             Log.trace("DTBroker3MDB:DTBroker3MDB()");
         }
         if (statInterval <= 0) {
-            statInterval = 1000;
+            statInterval = 10000;
         }
         mdbStats = MDBStats.getInstance();
     }
@@ -102,13 +102,12 @@ public class DTBroker3MDB implements MessageListener {
                     TimerStat currentStats = mdbStats.addTiming("DTBroker3MDB:neworder", publishTime, receiveTime);
 
                     if ((currentStats.getCount() % statInterval) == 0) {
-                        if (Log.doTrace()) {
-                            Log.log(new java.util.Date() + "\nDTBroker3MDB: processed " + statInterval + " stock trading orders. "
-                                + "\nCurrent NewOrder Message Statistics\n\tTotal NewOrders process = " + currentStats.getCount()
-                                + "\n\tTime to receive messages (in seconds):" + "\n\t\tmin: " + currentStats.getMinSecs() + "\n\t\tmax: "
-                                + currentStats.getMaxSecs() + "\n\t\tavg: " + currentStats.getAvgSecs() + "\n\n\n\tThe current order being processed is:\n\t"
-                                + ((TextMessage) message).getText());
-                        }
+                        Log.log(" DTBroker3MDB: processed " + statInterval + " stock trading orders." +
+                                " Total NewOrders process = " + currentStats.getCount() +
+                                "Time (in seconds):" +
+                                " min: " +currentStats.getMinSecs()+
+                                " max: " +currentStats.getMaxSecs()+
+                                " avg: " +currentStats.getAvgSecs());
                     }
                 } catch (Exception e) {
                     Log.error("DTBroker3MDB:onMessage Exception completing order: " + orderID + "\n", e);
@@ -131,11 +130,12 @@ public class DTBroker3MDB implements MessageListener {
                 TimerStat currentStats = mdbStats.addTiming("DTBroker3MDB:ping", publishTime, receiveTime);
 
                 if ((currentStats.getCount() % statInterval) == 0) {
-                    Log.log(new java.util.Date() + "\nDTBroker3MDB: received " + statInterval + " ping messages. "
-                            + "\nCurrent Ping Message Statistics\n\tTotal ping message count = " + currentStats.getCount()
-                            + "\n\tTime to receive messages (in seconds):" + "\n\t\tmin: " + currentStats.getMinSecs() + "\n\t\tmax: "
-                            + currentStats.getMaxSecs() + "\n\t\tavg: " + currentStats.getAvgSecs() + "\n\n\n\tThe current message is:\n\t"
-                            + ((TextMessage) message).getText());
+                    Log.log(" DTBroker3MDB: received " + statInterval + " ping messages." +
+                            " Total ping message count = " + currentStats.getCount() +
+                            " Time (in seconds):" +
+                            " min: " +currentStats.getMinSecs()+
+                            " max: " +currentStats.getMaxSecs()+
+                            " avg: " +currentStats.getAvgSecs());
                 }
             } else {
                 Log.error("DTBroker3MDB:onMessage - unknown message request command-->" + command + "<-- message=" + ((TextMessage) message).getText());

--- a/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java
+++ b/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/ejb3/DTStreamer3MDB.java
@@ -44,7 +44,7 @@ import com.ibm.websphere.samples.daytrader.util.WebSocketJMSMessage;
 public class DTStreamer3MDB implements MessageListener {
 
     private final MDBStats mdbStats;
-    private int statInterval = 1000;
+    private int statInterval = 10000;
 
     @Resource
     public MessageDrivenContext mdc;
@@ -55,7 +55,7 @@ public class DTStreamer3MDB implements MessageListener {
             Log.trace("DTStreamer3MDB:DTStreamer3MDB()");
         }
         if (statInterval <= 0) {
-            statInterval = 1000;
+            statInterval = 10000;
         }
         mdbStats = MDBStats.getInstance();
     }
@@ -89,13 +89,12 @@ public class DTStreamer3MDB implements MessageListener {
                 TimerStat currentStats = mdbStats.addTiming("DTStreamer3MDB:udpateQuote", publishTime, receiveTime);
 
                 if ((currentStats.getCount() % statInterval) == 0) {
-                    if (Log.doTrace()) {
-                        Log.trace(new java.util.Date() + "\nDTStreamer3MDB: " + statInterval + " Trade stock prices updated:  "
-                            + "\nCurrent Statistics\n\tTotal update Quote Price message count = " + currentStats.getCount()
-                            + "\n\tTime to receive stock update alerts messages (in seconds):" + "\n\t\tmin: " + currentStats.getMinSecs() + "\n\t\tmax: "
-                            + currentStats.getMaxSecs() + "\n\t\tavg: " + currentStats.getAvgSecs() + "\n\n\n\tThe current price update is:\n\t"
-                            + ((TextMessage) message).getText());
-                    }
+                    Log.log(" DTStreamer3MDB: " + statInterval + " prices updated:" +
+                            " Total message count = " + currentStats.getCount() +
+                            " Time (in seconds):" +
+                            " min: " +currentStats.getMinSecs()+
+                            " max: " +currentStats.getMaxSecs()+
+                            " avg: " +currentStats.getAvgSecs() );
                 }
                 
                 // Fire message to Websocket Endpoint
@@ -117,11 +116,12 @@ public class DTStreamer3MDB implements MessageListener {
                 TimerStat currentStats = mdbStats.addTiming("DTStreamer3MDB:ping", publishTime, receiveTime);
 
                 if ((currentStats.getCount() % statInterval) == 0) {
-                    Log.log(new java.util.Date() + "\nDTStreamer3MDB: received " + statInterval + " ping messages. "
-                            + "\nCurrent Ping Message Statistics\n\tTotal ping message count = " + currentStats.getCount()
-                            + "\n\tTime to receive messages (in seconds):" + "\n\t\tmin: " + currentStats.getMinSecs() + "\n\t\tmax: "
-                            + currentStats.getMaxSecs() + "\n\t\tavg: " + currentStats.getAvgSecs() + "\n\n\n\tThe current message is:\n\t"
-                            + ((TextMessage) message).getText());
+                    Log.log(" DTStreamer3MDB: received " + statInterval + " ping messages." +
+                            " Total message count = " + currentStats.getCount() +
+                            " Time (in seconds):" +
+                            " min: " +currentStats.getMinSecs()+
+                            " max: " +currentStats.getMaxSecs()+
+                            " avg: " +currentStats.getAvgSecs());
                 }
             } else {
                 Log.error("DTStreamer3MDB:onMessage - unknown message request command-->" + command + "<-- message=" + ((TextMessage) message).getText());

--- a/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/util/Log.java
+++ b/daytrader-ee7-ejb/src/main/java/com/ibm/websphere/samples/daytrader/util/Log.java
@@ -30,7 +30,6 @@ public class Log {
     // A general purpose, high performance logging, tracing, statistic service
 
     public static void log(String message) {
-       log.log(Level.INFO, "DayTrader Log:" + new java.util.Date() + "------\n\t ");
        log.log(Level.INFO, message);
     }
 


### PR DESCRIPTION
[6/15/17 10:26:33:862 EDT] 00000071 servlet       I
com.ibm.ws.webcontainer.servlet.ServletWrapper init SRVE0242I:
[daytrader-ee7.0.11] [/daytrader] [/account.jsp]: Initialization
successful.


[6/15/17 10:30:28:999 EDT] 00006731 daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 10000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.0114953
[6/15/17 10:33:23:971 EDT] 00000049 daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 20000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.0063157
[6/15/17 10:36:11:888 EDT] 00000057 daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 30000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.0046356999999999995
[6/15/17 10:39:04:061 EDT] 00007f30 daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 40000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.00385755
[6/15/17 10:42:00:082 EDT] 00023f25 daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 50000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.00342274
[6/15/17 10:45:00:304 EDT] 000241be daytrader     I    DTStreamer3MDB:
10000 prices updated: Total message count = 60000 Time (in seconds):
min: 0.0 max: 1.314 avg: 0.00314585

I have this liberty loggin spec:
<logging traceSpecification="daytrader=all" />