### PR TITLE
Change WebSockets code to take Session as a parameter

### DIFF
--- a/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/websocket/MarketSummaryWebSocket.java
+++ b/daytrader-ee7-web/src/main/java/com/ibm/websphere/samples/daytrader/web/websocket/MarketSummaryWebSocket.java
@@ -49,7 +49,6 @@ import com.ibm.websphere.samples.daytrader.util.WebSocketJMSMessage;
 public class MarketSummaryWebSocket {
 
 	private static final Set<Session> sessions = Collections.synchronizedSet(new HashSet<Session>());
-    private Session currentSession = null;   
     private final CountDownLatch latch = new CountDownLatch(1);
 
     @OnOpen
@@ -59,12 +58,11 @@ public class MarketSummaryWebSocket {
         }
 
         sessions.add(session);
-        currentSession = session;
         latch.countDown();
     } 
     
     @OnMessage
-    public void sendMarketSummary(ActionMessage message) {
+    public void sendMarketSummary(ActionMessage message, Session currentSession) {
 
         String action = message.getDecodedAction();
         
@@ -106,7 +104,7 @@ public class MarketSummaryWebSocket {
     }
 
     @OnError
-    public void onError(Throwable t) {
+    public void onError(Throwable t, Session currentSession) {
         if (Log.doTrace()) {
             Log.trace("MarketSummaryWebSocket:onError -- session -->" + currentSession + "<--");
         }


### PR DESCRIPTION
Just tidying up to use what seems to be the more standard way of accessing the session by taking it as a parameter instead of storing it as an instance variable:

"and an optional Session parameter"
https://docs.oracle.com/javaee/7/api/javax/websocket/OnMessage.html

"optional Session parameter"
https://docs.oracle.com/javaee/7/api/javax/websocket/OnError.html

It's not immediately clear that it's safe to store per-session data as instance variables in the ServerEndpoint: https://docs.oracle.com/javaee/7/api/javax/websocket/server/ServerEndpoint.html

Tested this change and it works.