### PR TITLE
Fix: Could not find method leftShift()

### DIFF
--- a/daytrader-ee7-wlpcfg/build.gradle
+++ b/daytrader-ee7-wlpcfg/build.gradle
@@ -1,6 +1,8 @@
-task clean << {
-    ant.delete(includeemptydirs: 'true') {
-        fileset(dir: 'servers', includes: '**/logs/**, **/apps/*, **/workarea/**')
-        fileset(dir: 'shared/resources', includes: '**/data/**, **/Daytrader7SampleDerbyLibs/*')
+task clean {
+    doLast {
+        ant.delete(includeemptydirs: 'true') {
+            fileset(dir: 'servers', includes: '**/logs/**, **/apps/*, **/workarea/**')
+            fileset(dir: 'shared/resources', includes: '**/data/**, **/Daytrader7SampleDerbyLibs/*')
+        }
     }
 }


### PR DESCRIPTION
This is per issue #17.
gradlew build failed with the following message
* What went wrong:
A problem occurred evaluating project ':daytrader-ee7-wlpcfg'.
> Could not find method leftShift() for arguments
[build_dwp93g3073ftz5br8hfg76w5e$_run_closure1@7d6e1bc6] on task
':daytrader-ee7-wlpcfg:clean' of type org.gradle.api.DefaultTask.

It appears that the left shift operator is being deprecated in Gradle
3.2 per
https://docs.gradle.org/3.2/release-notes.html#the-left-shift-operator-on-the-task-interface

Action: replace << with doLast method
https://discuss.gradle.org/t/could-not-find-method-leftshift-for-arguments-on-task-of-type-org-gradle-api-defaulttask/30614/2