### PR TITLE
update db2 information in deploy folder

### DIFF
--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -1,38 +1,37 @@
-apiVersion: liberty.websphere.ibm.com/v1
-kind: WebSphereLibertyApplication
+apiVersion: apps.openliberty.io/v1beta2
+kind: OpenLibertyApplication
 metadata:
   name: daytrader7
   annotations:
     argocd.argoproj.io/sync-wave: "3"
 spec:
-  license:
-    accept: true
-    edition: IBM WebSphere Application Server
-    productEntitlementSource: Standalone
-    metric: Virtual Processor Core (VPC)
   applicationImage: 'docker.io/dguinan/sample-daytrader7:latest'
-  pullPolicy: Always
-  replicas: 1
   route:
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      cert-manager.io/cluster-issuer: letsencrypt
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      nginx.ingress.kubernetes.io/affinity: "cookie"
-      nginx.ingress.kubernetes.io/session-cookie-name: "route"
-      nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    host: svtdemo.green-chesterfield.com
-    certificateSecretRef: tls-secret
     path: /daytrader
-    pathType: Prefix    
   expose: true
   service:
-    port: 9443
+    portName: liveness-port
+    port: 9082
     type: ClusterIP
   probes:
-    startup: {}
-    liveness: {}
-    readiness: {}
+    startup:
+      httpGet:
+        path: /health
+        port: liveness-port
+      failureThreshold: 10
+      periodSeconds: 10
+    liveness:
+      httpGet:
+        path: /health
+        port: liveness-port
+      failureThreshold: 5
+      periodSeconds: 10
+    readiness:
+      httpGet:
+        path: /daytrader
+        port: liveness-port
+      failureThreshold: 5
+      periodSeconds: 10
   env:
     - name: tradeDbHost
       value: trade-db2
@@ -47,6 +46,7 @@ spec:
         secretKeyRef:
           name: db-credential
           key: dbpw
+  pullPolicy: Always
   resources:
     requests:
       cpu: 500m

--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -43,7 +43,10 @@ spec:
     - name: dbUser
       value: db2inst1
     - name: dbPass
-      value: passw0rd
+      valueFrom:
+        secretKeyRef:
+          name: db-credential
+          key: dbpw
   resources:
     requests:
       cpu: 500m

--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -10,7 +10,7 @@ spec:
     edition: IBM WebSphere Application Server
     productEntitlementSource: Standalone
     metric: Virtual Processor Core (VPC)
-    applicationImage: 'docker.io/dguinan/sample-daytrader7:latest'
+  applicationImage: 'docker.io/dguinan/sample-daytrader7:latest'
   pullPolicy: Always
   replicas: 1
   route:

--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -1,37 +1,38 @@
-apiVersion: apps.openliberty.io/v1beta2
-kind: OpenLibertyApplication
+apiVersion: liberty.websphere.ibm.com/v1
+kind: WebSphereLibertyApplication
 metadata:
   name: daytrader7
   annotations:
     argocd.argoproj.io/sync-wave: "3"
 spec:
-  applicationImage: 'docker.io/dguinan/sample-daytrader7:latest'
+  license:
+    accept: true
+    edition: IBM WebSphere Application Server
+    productEntitlementSource: Standalone
+    metric: Virtual Processor Core (VPC)
+        applicationImage: ' docker.io/dguinan/sample-daytrader7:latest'
+  pullPolicy: Always
+  replicas: 1
   route:
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/session-cookie-name: "route"
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+    host: svtaks.green-chesterfield.com
+    certificateSecretRef: tls-secret
     path: /daytrader
+    pathType: Prefix    
   expose: true
   service:
-    portName: liveness-port
-    port: 9082
+    port: 9443
     type: ClusterIP
   probes:
-    startup:
-      httpGet:
-        path: /health
-        port: liveness-port
-      failureThreshold: 10
-      periodSeconds: 10
-    liveness:
-      httpGet:
-        path: /health
-        port: liveness-port
-      failureThreshold: 5
-      periodSeconds: 10
-    readiness:
-      httpGet:
-        path: /daytrader
-        port: liveness-port
-      failureThreshold: 5
-      periodSeconds: 10
+    startup: {}
+    liveness: {}
+    readiness: {}
   env:
     - name: tradeDbHost
       value: trade-db2
@@ -43,9 +44,6 @@ spec:
       value: db2inst1
     - name: dbPass
       value: passw0rd
-    - name: traceString
-      value: " "
-  pullPolicy: Always
   resources:
     requests:
       cpu: 500m

--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -21,7 +21,7 @@ spec:
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/session-cookie-name: "route"
       nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    host: svtaks.green-chesterfield.com
+    host: svtdemo.green-chesterfield.com
     certificateSecretRef: tls-secret
     path: /daytrader
     pathType: Prefix    

--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -10,7 +10,7 @@ spec:
     edition: IBM WebSphere Application Server
     productEntitlementSource: Standalone
     metric: Virtual Processor Core (VPC)
-        applicationImage: ' docker.io/dguinan/sample-daytrader7:latest'
+    applicationImage: 'docker.io/dguinan/sample-daytrader7:latest'
   pullPolicy: Always
   replicas: 1
   route:

--- a/deploy/db2-secret.yaml
+++ b/deploy/db2-secret.yaml
@@ -2,6 +2,8 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: db-credential
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 data:
   dbpw: cGFzc3cwcmQ=
 type: Opaque

--- a/deploy/db2-secret.yaml
+++ b/deploy/db2-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: db-credential
+data:
+  dbpw: cGFzc3cwcmQ=
+type: Opaque

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -24,7 +24,10 @@ spec:
           name: trade-db2
           env:
             - name: DB2INST1_PASSWORD
-              value: passw0rd
+              valueFrom:
+                secretKeyRef:
+                  name: db-credential
+                  key: dbpw
             - name: LICENSE
               value: accept
             - name: APP

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -30,8 +30,8 @@ spec:
                   key: dbpw
             - name: LICENSE
               value: accept
-            - name: APP
-              value: daytrader7
+            - name: DBNAME
+              value: tradedb
           securityContext:
             capabilities:
             privileged: true
@@ -42,7 +42,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
           terminationMessagePolicy: File
-          image: docker.io/tamdocker/trade7db:latest
+          image: docker.io/tamdocker/trade7db2:latest
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -30,8 +30,8 @@ spec:
                   key: dbpw
             - name: LICENSE
               value: accept
-            - name: DBNAME
-              value: tradedb
+            #- name: DBNAME
+            #  value: tradedb
           securityContext:
             capabilities:
             privileged: true

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -30,8 +30,6 @@ spec:
                   key: dbpw
             - name: LICENSE
               value: accept
-            #- name: DBNAME
-            #  value: tradedb
           securityContext:
             capabilities:
             privileged: true

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -27,8 +27,8 @@ spec:
               value: passw0rd
             - name: LICENSE
               value: accept
-            - name: DBNAME
-              value: tradedb
+            - name: APP
+              value: daytrader7
           securityContext:
             capabilities:
             privileged: true

--- a/deploy/tradedb.yaml
+++ b/deploy/tradedb.yaml
@@ -40,7 +40,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
           terminationMessagePolicy: File
-          image: docker.io/tamdocker/trade7db2:latest
+          image: docker.io/tamdocker/trade7db:latest
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
- add db2-secret.yaml and use _db-credential_ secret in tradedb.yaml and daytrader7-deploy.yaml instead of plain text password 
- remove env var DBNAME in tradedb.yaml because TRADEDB database will be created when it runs _db2 restore database_ command
- remove env var traceString in daytrader7-deploy.yaml because it's not being used