### PR TITLE
Update daytrader7-deploy.yaml

### DIFF
--- a/deploy/daytrader7-deploy.yaml
+++ b/deploy/daytrader7-deploy.yaml
@@ -50,7 +50,7 @@ spec:
   resources:
     requests:
       cpu: 500m
-      memory: 1024Mi
+      memory: 1Gi
     limits:
       cpu: 500m
-      memory: 2048Mi
+      memory: 2Gi


### PR DESCRIPTION
Changing Deployment requests to `Gi` format due to OCP constantly converting `1024Mi` to `1Gi` causing a sync loop.